### PR TITLE
ci(test): using docker images for test and updating to Slack orb v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - run: docker push aegee/discounts:latest
       - slack/notify:
           event: pass
-          template: success_tagged_deploy_1
+          template: basic_success_1
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -106,17 +106,16 @@ workflows:
       - test
   docker-build-and-push:
     jobs:
-      - docker-build-and-push
-  #     - docker-build-and-push:
-  #         filters:
-  #           branches:
-  #             only: master
+      - docker-build-and-push:
+          filters:
+            branches:
+              only: master
   audit:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * 5"
-    #       filters:
-    #         branches:
-    #           only: master
+    triggers:
+      - schedule:
+          cron: "0 0 * * 5"
+          filters:
+            branches:
+              only: master
     jobs:
       - audit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,11 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: docker build --tag aegee/discounts:$(node -p "require('./package.json').version") --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
+      - run: `export PACKAGE_VERSION=$(node -p "require('./package.json').version")` >> $BASH_ENV
+      - run: docker build --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
-      - run: docker push aegee/discounts:$(node -p "require('./package.json').version")
+      - run: docker push aegee/discounts:$PACKAGE_VERSION
       - run: docker push aegee/discounts:latest
-      - run: PACKAGE_VERSION=$(node -p "require('./package.json').version")
       - slack/notify:
           event: pass
           custom: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,10 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: echo $(node -p "require('./package.json').version") >> $VERSION
-      - run: docker build  --tag aegee/discounts:$VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
+      - run: echo $(node -p "require('./package.json').version") >> $PACKAGE_VERSION
+      - run: docker build  --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
-      - run: docker push aegee/discounts:$VERSION
+      - run: docker push aegee/discounts:$PACKAGE_VERSION
       - run: docker push aegee/discounts:latest
       - slack/notify:
           event: pass
@@ -100,7 +100,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$VERSION` and `latest` has been pushed to Dockerhub."
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$PACKAGE_VERSION` and `latest` has been pushed to Dockerhub."
                   }
                 }
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,18 @@ jobs:
       - run: npm audit --production
       - slack/notify:
           event: fail
-          template: basic_fail_1
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The audit check for `$CIRCLE_PROJECT_REPONAME` has failed."
+                  }
+                }
+              ]
+            }
   docker-build-and-push:
     docker:
       - image: cimg/node:14.17.3
@@ -81,10 +92,32 @@ jobs:
       - run: docker push aegee/discounts:latest
       - slack/notify:
           event: pass
-          template: basic_success_1
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$(node -p "require('./package.json').version")` and `latest` has been pushed to Dockerhub."
+                  }
+                }
+              ]
+            }
       - slack/notify:
           event: fail
-          template: basic_fail_1
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` build and push has failed."
+                  }
+                }
+              ]
+            }
 
 workflows:
   version: 2
@@ -106,10 +139,11 @@ workflows:
       - test
   docker-build-and-push:
     jobs:
-      - docker-build-and-push:
-          filters:
-            branches:
-              only: master
+      - docker-build-and-push
+      # - docker-build-and-push:
+      #     filters:
+      #       branches:
+      #         only: master
   audit:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,6 @@ jobs:
           POSTGRES_PASSWORD: 5ecr3t
     steps:
       - checkout
-      - run:
-          name: Install Node
-          command: |
-            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-            echo ' [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-            nvm install v14.16.0
-            nvm alias default v14.16.0
       - node/install-packages
       - run: mkdir -p ~/reports/jest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: echo $(node -p "require('./package.json').version") >> "$PACKAGE_VERSION"
+      - run: PACKAGE_VERSION = $(node -p "require('./package.json').version")
       - run: docker build  --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/discounts:$PACKAGE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,10 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: docker build  --tag aegee/discounts:$(node -p "require('./package.json').version") --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
+      - run: echo $(node -p "require('./package.json').version") >> $VERSION
+      - run: docker build  --tag aegee/discounts:$VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
-      - run: docker push aegee/discounts:$(node -p "require('./package.json').version")
+      - run: docker push aegee/discounts:$VERSION
       - run: docker push aegee/discounts:latest
       - slack/notify:
           event: pass
@@ -99,7 +100,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$(node -p \"require('./package.json').version\")` and `latest` has been pushed to Dockerhub."
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$VERSION` and `latest` has been pushed to Dockerhub."
                   }
                 }
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
     docker:
       - image: cimg/node:14.17.3
     environment:
-      PACKAGE_VERSION: $(node -p "require('./package.json').version")
+      PACKAGE_VERSION: $(cat package.json | grep version | head -1 | awk -F= "{ print $2 }" | sed 's/[version:,\",]//g' | tr -d '[[:space:]]')
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$(node -p 'require('\''./package.json'\'').version')` and `latest` has been pushed to Dockerhub."
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$(node -p \"require('./package.json').version\")` and `latest` has been pushed to Dockerhub."
                   }
                 }
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,11 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: PACKAGE_VERSION=$(node -p "require('./package.json').version")
-      - run: docker build --tag aegee/discounts:${PACKAGE_VERSION} --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
+      - run: docker build --tag aegee/discounts:$(node -p "require('./package.json').version") --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
-      - run: docker push aegee/discounts:${PACKAGE_VERSION}
+      - run: docker push aegee/discounts:$(node -p "require('./package.json').version")
       - run: docker push aegee/discounts:latest
+      - run: PACKAGE_VERSION=$(node -p "require('./package.json').version")
       - slack/notify:
           event: pass
           custom: |
@@ -100,7 +100,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `${PACKAGE_VERSION}` and `latest` has been pushed to Dockerhub."
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$PACKAGE_VERSION` and `latest` has been pushed to Dockerhub."
                   }
                 }
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,6 @@ jobs:
   docker-build-and-push:
     docker:
       - image: cimg/node:14.17.3
-    environment:
-      PACKAGE_VERSION: $(cat package.json | grep version | head -1 | awk -F= "{ print $2 }" | sed 's/[version:,\",]//g' | tr -d '[[:space:]]')
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,16 @@ jobs:
       - image: circleci/postgres:10.17
         environment:
           POSTGRES_PASSWORD: 5ecr3t
+    parallelism: 4
     steps:
       - checkout
       - node/install-packages
       - run: mkdir -p ~/reports/jest
       - run:
           name: Run tests
-          command: JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm test -- --reporters=default --reporters=jest-junit
+          command: |
+            TEST=$(circleci tests glob test/api/*.js | circleci tests split --split-by=timings)
+            JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm test:ci -- --reporters=default --reporters=jest-junit
       - run: ./node_modules/.bin/codecov
       - store_test_results:
           path: ~/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: PACKAGE_VERSION= $(node -p "require('./package.json').version")
+      - run: PACKAGE_VERSION=$(node -p "require('./package.json').version")
       - run: docker build  --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/discounts:$PACKAGE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Run tests
           command: |
             TEST=$(circleci tests glob test/api/*.js | circleci tests split --split-by=timings)
-            JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm test:ci -- --reporters=default --reporters=jest-junit
+            JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm test:ci $TEST -- --reporters=default --reporters=jest-junit
       - run: ./node_modules/.bin/codecov
       - store_test_results:
           path: ~/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,13 @@ orbs:
 version: 2.1
 jobs:
   test:
-    machine:
-      image: ubuntu-2004:202101-01
+    docker:
+      - image: cimg/node:14.17.3
+      - image: circleci/postgres:10.17
+        environment:
+          POSTGRES_PASSWORD: 5ecr3t
     steps:
       - checkout
-      - run: docker run --name postgres -e POSTGRES_PASSWORD='5ecr3t' -p 5432:5432 -d postgres:10.16
       - run:
           name: Install Node
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,10 @@ workflows:
       - test
   docker-build-and-push:
     jobs:
-      - docker-build-and-push
-      # - docker-build-and-push:
-      #     filters:
-      #       branches:
-      #         only: master
+      - docker-build-and-push:
+          filters:
+            branches:
+              only: master
   audit:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
+      - run: echo export PACKAGE_VERSION=$(node -p "require('./package.json').version") >> $BASH_ENV
       - run: docker build --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/discounts:$PACKAGE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,13 +80,14 @@ jobs:
   docker-build-and-push:
     docker:
       - image: cimg/node:14.17.3
+    environment:
+      PACKAGE_VERSION: $(node -p "require('./package.json').version")
     steps:
       - checkout
       - setup_remote_docker:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: `export PACKAGE_VERSION=$(node -p "require('./package.json').version")` >> $BASH_ENV
       - run: docker build --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/discounts:$PACKAGE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 orbs:
   slack: circleci/slack@3.4.2 # FIXME update to v4
-  node: circleci/node@4.2.0
-  shellcheck: circleci/shellcheck@2.2.2
-  docker: circleci/docker@1.5.0
+  node: circleci/node@4.5.1
+  shellcheck: circleci/shellcheck@2.2.4
+  docker: circleci/docker@1.6.0
 version: 2.1
 jobs:
   test:
@@ -25,15 +25,15 @@ jobs:
           path: ~/reports
   build:
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2021.07
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: 20.10.6
       - run: docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache discounts
   eslint:
     docker:
-      - image: cimg/node:14.16.0
+      - image: cimg/node:14.17.3
     steps:
       - checkout
       - node/install-packages
@@ -45,21 +45,21 @@ jobs:
           path: ~/reports
   yamllint:
     docker:
-      - image: cimg/python:3.9.2
+      - image: cimg/python:3.9.6
     steps:
       - checkout
       - run: pip install yamllint
       - run: yamllint -d .yamllint.yml .
   shellcheck:
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2021.07
     steps:
       - checkout
       - shellcheck/install
       - shellcheck/check
   audit:
     docker:
-      - image: cimg/node:14.16.0
+      - image: cimg/node:14.17.3
     steps:
       - checkout
       - run: npm audit --production
@@ -68,11 +68,11 @@ jobs:
           failure_message: The audit check for \`$CIRCLE_PROJECT_REPONAME\` has failed.
   docker-build-and-push:
     docker:
-      - image: cimg/node:14.16.0
+      - image: cimg/node:14.17.3
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
       - run: docker build  --tag aegee/discounts:$(node -p "require('./package.json').version") --tag aegee/discounts:latest -f docker/discounts/Dockerfile .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: echo $(node -p "require('./package.json').version") >> $PACKAGE_VERSION
+      - run: echo $(node -p "require('./package.json').version") >> "$PACKAGE_VERSION"
       - run: docker build  --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/discounts:$PACKAGE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  slack: circleci/slack@3.4.2 # FIXME update to v4
+  slack: circleci/slack@4.4.2
   node: circleci/node@4.5.1
   shellcheck: circleci/shellcheck@2.2.4
   docker: circleci/docker@1.6.0
@@ -63,9 +63,9 @@ jobs:
     steps:
       - checkout
       - run: npm audit --production
-      - slack/status:
-          fail_only: true
-          failure_message: The audit check for \`$CIRCLE_PROJECT_REPONAME\` has failed.
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
   docker-build-and-push:
     docker:
       - image: cimg/node:14.17.3
@@ -79,9 +79,12 @@ jobs:
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/discounts:$(node -p "require('./package.json').version")
       - run: docker push aegee/discounts:latest
-      - slack/status:
-          success_message: The Docker image for \`$CIRCLE_PROJECT_REPONAME\` with tags \`$(node -p "require('./package.json').version")\` and \`latest\` has been pushed to Dockerhub.
-          failure_message: The Docker image for \`$CIRCLE_PROJECT_REPONAME\` build and push has failed.
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
 
 workflows:
   version: 2
@@ -103,16 +106,17 @@ workflows:
       - test
   docker-build-and-push:
     jobs:
-      - docker-build-and-push:
-          filters:
-            branches:
-              only: master
+      - docker-build-and-push
+  #     - docker-build-and-push:
+  #         filters:
+  #           branches:
+  #             only: master
   audit:
-    triggers:
-      - schedule:
-          cron: "0 0 * * 5"
-          filters:
-            branches:
-              only: master
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * 5"
+    #       filters:
+    #         branches:
+    #           only: master
     jobs:
       - audit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$(node -p "require('./package.json').version")` and `latest` has been pushed to Dockerhub."
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$(node -p 'require('\''./package.json'\'').version')` and `latest` has been pushed to Dockerhub."
                   }
                 }
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,9 @@ jobs:
       - node/install-packages
       - run: npx semantic-release
       - run: PACKAGE_VERSION=$(node -p "require('./package.json').version")
-      - run: docker build  --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
+      - run: docker build --tag aegee/discounts:${PACKAGE_VERSION} --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
-      - run: docker push aegee/discounts:$PACKAGE_VERSION
+      - run: docker push aegee/discounts:${PACKAGE_VERSION}
       - run: docker push aegee/discounts:latest
       - slack/notify:
           event: pass
@@ -100,7 +100,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `$PACKAGE_VERSION` and `latest` has been pushed to Dockerhub."
+                    "text": "The Docker image for `$CIRCLE_PROJECT_REPONAME` with tags `${PACKAGE_VERSION}` and `latest` has been pushed to Dockerhub."
                   }
                 }
               ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Run tests
           command: |
             TEST=$(circleci tests glob test/api/*.js | circleci tests split --split-by=timings)
-            JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm test:ci $TEST -- --reporters=default --reporters=jest-junit
+            JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm run test:ci $TEST -- --reporters=default --reporters=jest-junit
       - run: ./node_modules/.bin/codecov
       - store_test_results:
           path: ~/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           version: 20.10.6
       - node/install-packages
       - run: npx semantic-release
-      - run: PACKAGE_VERSION = $(node -p "require('./package.json').version")
+      - run: PACKAGE_VERSION= $(node -p "require('./package.json').version")
       - run: docker build  --tag aegee/discounts:$PACKAGE_VERSION --tag aegee/discounts:latest -f docker/discounts/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/discounts:$PACKAGE_VERSION

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 ### OMS DISCOUNTS     #######################################
 services:
     postgres-discounts:
-        image: postgres:10
+        image: postgres:10.17
         volumes:
             - postgres-discounts:/var/lib/postgresql/data
         expose:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:setup": "sequelize db:drop; sequelize db:create; sequelize db:migrate",
     "db:migrate": "sequelize db:migrate",
     "test": "NODE_ENV=test npm run db:setup && jest test/api/*.js --runInBand --forceExit",
+    "test:ci": "NODE_ENV=test npm run db:setup && jest --runInBand --forceExit",
     "open-coverage": "opn coverage/lcov-report/index.html",
     "prepare": "husky install"
   },


### PR DESCRIPTION
I've finished the final things that I wanted to do for the CircleCI config and I've updated everything to the latest version.

I've also written a guide on what needs updating and where the latest versions can be found; https://myaegee.atlassian.net/l/c/CH731sTD

V4 of the Slack orb uses a different setup, so a new Slack app was created for this. The old one with webhooks can be removed after this PR is merged on all repos. A preview of the new Slack messages can be found here; https://github.com/CircleCI-Public/slack-orb/wiki