### PR TITLE
chore(ci): update CircleCI orbs and images to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,14 @@
 orbs:
   codecov: codecov/codecov@5.4.3
-  docker: circleci/docker@2.8.2
-  node: circleci/node@7.1.1
+  node: circleci/node@7.2.1
   shellcheck: circleci/shellcheck@3.4.0
-  slack: circleci/slack@5.2.0
+  slack: circleci/slack@6.1.2
 version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/node:22.18.0
-      - image: cimg/postgres:17.5
+      - image: cimg/node:22.20.0
+      - image: cimg/postgres:17.6
         environment:
           POSTGRES_PASSWORD: config.test.postgres.password
     parallelism: 4
@@ -30,7 +29,7 @@ jobs:
           path: ~/reports
   build:
     docker:
-      - image: cimg/base:2025.08
+      - image: cimg/base:2025.12
     resource_class: large
     steps:
       - checkout
@@ -39,7 +38,7 @@ jobs:
       - run: docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache discounts
   eslint:
     docker:
-      - image: cimg/node:22.18.0
+      - image: cimg/node:22.20.0
     resource_class: large
     steps:
       - checkout
@@ -52,7 +51,7 @@ jobs:
           path: ~/reports
   yamllint:
     docker:
-      - image: cimg/python:3.13.6
+      - image: cimg/python:3.13.11
     resource_class: large
     steps:
       - checkout
@@ -68,7 +67,7 @@ jobs:
           command: hadolint $(find . -name '*Dockerfile*')
   shellcheck:
     docker:
-      - image: cimg/base:2025.08
+      - image: cimg/base:2025.12
     resource_class: large
     steps:
       - checkout
@@ -76,7 +75,7 @@ jobs:
       - shellcheck/check
   audit:
     docker:
-      - image: cimg/node:22.18.0
+      - image: cimg/node:22.20.0
     resource_class: large
     steps:
       - checkout
@@ -123,7 +122,7 @@ jobs:
             }
   docker-build-and-push:
     docker:
-      - image: cimg/node:22.18.0
+      - image: cimg/node:22.20.0
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
## Summary
- Update node orb: 7.1.1 → 7.2.1
- Update slack orb: 5.2.0 → 6.1.2
- Remove unused docker orb
- Update cimg/node: 22.18.0 → 22.20.0
- Update cimg/postgres: 17.5 → 17.6
- Update cimg/base: 2025.08 → 2025.12
- Update cimg/python: 3.13.6 → 3.13.11

## Test plan
- [ ] Verify CircleCI builds pass with new versions

🤖 Generated with [Claude Code](https://claude.ai/code)